### PR TITLE
Enable Gradle daemon in test environment

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,7 +30,7 @@ grails.project.dependency.resolver = "maven" // or ivy
 //]
 grails.project.fork = [
     run: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, forkReserve:false],
-    test: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, forkReserve:false, jvmArgs: ["-Dwebdriver.chrome.driver="+env["CHROMEDRIVER"]]]
+    test: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, forkReserve:false, daemon:true, jvmArgs: ["-Dwebdriver.chrome.driver="+env["CHROMEDRIVER"]]]
 ]
 
 grails.project.dependency.resolution = {


### PR DESCRIPTION
Speeds up development & test cycle when using Gradle's interactive console by keeping a Java process running in background that gets automatically synced with code changes and allows immediate running of unit tests.

Doesn't affect production / development environments. IntelliJ skips daemon but interactive console respects.
