### PR TITLE
CORE-732: Force TimeSeriesInput to receive doubles

### DIFF
--- a/src/java/com/unifina/signalpath/TimeSeriesInput.java
+++ b/src/java/com/unifina/signalpath/TimeSeriesInput.java
@@ -7,6 +7,11 @@ public class TimeSeriesInput extends PrimitiveInput<Double> {
 	}
 
 	@Override
+	public void receive(Object value) {
+		super.receive(((Number) value).doubleValue()); // Ensure that integers are received as Doubles
+	}
+
+	@Override
 	protected Double parseInitialValue(String initialValue) {
 		return Double.parseDouble(initialValue);
 	}


### PR DESCRIPTION
Prevent casting errors from occurring.
