### PR TITLE
CORE-764: front-end support for canConnect=false

### DIFF
--- a/src/groovy/com/unifina/signalpath/SignalPathParameter.groovy
+++ b/src/groovy/com/unifina/signalpath/SignalPathParameter.groovy
@@ -6,6 +6,7 @@ class SignalPathParameter extends Parameter<Canvas> {
 	
 	public SignalPathParameter(AbstractSignalPathModule owner, String name) {
 		super(owner, name, null, "Canvas");
+		setCanConnect(false)
 	}
 	
 	public Map<String,Object> getConfiguration() {

--- a/src/java/com/unifina/signalpath/Endpoint.java
+++ b/src/java/com/unifina/signalpath/Endpoint.java
@@ -17,7 +17,7 @@ public abstract class Endpoint<T> implements Serializable {
 	private Map<String,Object> json;
 	private boolean configured = false;
 	
-	protected boolean canConnect = true;
+	private boolean canConnect = true;
 	protected List<String> aliases = null;
 	
 	public Endpoint(AbstractSignalPathModule owner, String name, String typeName) {
@@ -73,7 +73,11 @@ public abstract class Endpoint<T> implements Serializable {
 	}
 	
 	public abstract boolean isConnected();
-	
+
+	public void setCanConnect(boolean canConnect) {
+		this.canConnect = canConnect;
+	}
+
 	public void regenerateId() {
 		id = IdGenerator.get();
 	}

--- a/src/java/com/unifina/signalpath/Parameter.java
+++ b/src/java/com/unifina/signalpath/Parameter.java
@@ -19,7 +19,6 @@ public abstract class Parameter<T> extends Input<T> {
 	
 	public boolean canBeEmpty = true;
 	private boolean updateOnChange = false;
-	private boolean unconnectable = false;
 	
 	public Parameter(AbstractSignalPathModule owner, String name, T defaultValue, String typeName) {
 		super(owner, name, typeName);
@@ -114,10 +113,6 @@ public abstract class Parameter<T> extends Input<T> {
 		if (updateOnChange) {
 			config.put("updateOnChange", true);
 		}
-
-		if (unconnectable) {
-			config.put("unconnectable", true);
-		}
 		
 		return config;
 	}
@@ -194,13 +189,5 @@ public abstract class Parameter<T> extends Input<T> {
 
 	public void setUpdateOnChange(boolean updateOnChange) {
 		this.updateOnChange = updateOnChange;
-	}
-
-	public boolean isUnconnectable() {
-		return unconnectable;
-	}
-
-	public void setUnconnectable(boolean unconnectable) {
-		this.unconnectable = unconnectable;
 	}
 }

--- a/src/java/com/unifina/signalpath/list/ForEachItem.java
+++ b/src/java/com/unifina/signalpath/list/ForEachItem.java
@@ -26,6 +26,12 @@ public class ForEachItem extends AbstractSignalPathModule {
 	}
 
 	@Override
+	public void init() {
+		addInput(signalPathParameter);
+		addInput(keepState);
+	}
+
+	@Override
 	protected void onConfiguration(Map<String, Object> config) {
 		super.onConfiguration(config);
 

--- a/src/java/com/unifina/signalpath/simplemath/Expression.java
+++ b/src/java/com/unifina/signalpath/simplemath/Expression.java
@@ -19,7 +19,7 @@ public class Expression extends AbstractSignalPathModule {
 	@Override
 	public void init() {
 		expressionParam.setUpdateOnChange(true);
-		expressionParam.setUnconnectable(true);
+		expressionParam.setCanConnect(false);
 
 		addInput(expressionParam);
 		addOutput(out);

--- a/web-app/js/unifina/signalPath/core/Input.js
+++ b/web-app/js/unifina/signalPath/core/Input.js
@@ -38,6 +38,10 @@ SignalPath.Input = function(json, parentDiv, module, type, pub) {
 
 		// The flags must be appended in reverse order
 
+		if (data.canConnect === false) {
+			return;
+		}
+
 		// Feedback connection. Default false. Switchable for TimeSeries types.
 		if (data.type=="Double" && (data.canBeFeedback==null || data.canBeFeedback)) {
 			var feedback = new SignalPath.IOSwitch(switchDiv, "ioSwitch feedback", {

--- a/web-app/js/unifina/signalPath/generic/genericModule.js
+++ b/web-app/js/unifina/signalPath/generic/genericModule.js
@@ -167,7 +167,9 @@ SignalPath.GenericModule = function(data, canvas, prot) {
 		
 		if (hold) {
 			$.each(getEndpoints(), function(i, endpoint) {
-				endpoint.jsPlumbEndpoint.addClass("holdFocus");
+				if (endpoint.jsPlumbEndpoint) {
+					endpoint.jsPlumbEndpoint.addClass("holdFocus");
+				}
 			})
 		}
 	}
@@ -212,7 +214,9 @@ SignalPath.GenericModule = function(data, canvas, prot) {
 		super_removeFocus();
 
 		$.each(getEndpoints(), function(i, endpoint) {
-			endpoint.jsPlumbEndpoint.removeClass("holdFocus");
+			if (endpoint.jsPlumbEndpoint) {
+				endpoint.jsPlumbEndpoint.removeClass("holdFocus");
+			}
 		})
 	}
 	


### PR DESCRIPTION
Don't show js plumb endpoint for endpoints that have canConnect set to false.
Also get rid of field unconnectable for Parameter since canConnect does the
same thing.

TODO:
- enforce connectionlessness in back-end?