### PR TITLE
CORE-811: send debug error ui msgs from module

### DIFF
--- a/grails-app/conf/UnifinaCorePluginResources.groovy
+++ b/grails-app/conf/UnifinaCorePluginResources.groovy
@@ -250,6 +250,7 @@ modules = {
 	}
 	'canvas-controls' {
 		dependsOn 'signalpath-core, backbone'
+		resource url:[dir:'js/unifina/signalPath/controls', file:'canvas-debug-viewer.js', plugin: 'unifina-core']
 		resource url:[dir:'js/unifina/signalPath/controls', file:'canvas-start-button.js', plugin: 'unifina-core']
 		resource url:[dir:'js/unifina/signalPath/controls', file:'canvas-name-editor.js', plugin: 'unifina-core']
 	}

--- a/grails-app/views/canvas/editor.gsp
+++ b/grails-app/views/canvas/editor.gsp
@@ -290,6 +290,19 @@ $(document).ready(function() {
 		signalPath: SignalPath
 	})
 
+	var moduleDebugMessageList = new ModuleDebugMessageList()
+	new CanvasDebugViewer({
+	    el: $("#canvas-debug-viewer"),
+	    collection: moduleDebugMessageList,
+	    isAdhoc: SignalPath.isAdhoc.bind(SignalPath)
+	})
+	$(SignalPath).on("moduleDebugMessage", function(event, msg) {
+	    moduleDebugMessageList.add(msg)
+	})
+	$(SignalPath).on("loaded starting", function() {
+	   moduleDebugMessageList.reset()
+	})
+
 	$(SignalPath).on('new', function(e, json) {
 		$("#share-button").attr("disabled", "disabled")
 	})
@@ -462,6 +475,7 @@ $(document).unload(function () {
 			</li>
 		</ui:breadcrumb>
 		<div id="canvas" class="scrollable embeddable"></div>
+		<div id="canvas-debug-viewer"></div>
 	</div>
 
 	<div id="main-menu-bg"></div>

--- a/src/java/com/unifina/signalpath/AbstractSignalPathModule.java
+++ b/src/java/com/unifina/signalpath/AbstractSignalPathModule.java
@@ -68,6 +68,7 @@ public abstract class AbstractSignalPathModule implements IEventRecipient, IDayL
 	private transient Globals globals;
 
 	private boolean initialized;
+	private boolean debugMessagesEnabled = true;
 
 	private static final Logger log = Logger.getLogger(AbstractSignalPathModule.class);
 
@@ -579,6 +580,22 @@ public abstract class AbstractSignalPathModule implements IEventRecipient, IDayL
 		return initPriority;
 	}
 
+	public boolean isDebugMessagesEnabled() {
+		return debugMessagesEnabled;
+	}
+
+	protected void pushDebugMessage(String message) {
+		if (isDebugMessagesEnabled() && getParentSignalPath().isDebugMessagesEnabled()) {
+			getParentSignalPath().pushToUiChannel(new ModuleDebugMessage(message, this));
+		}
+	}
+
+	protected void pushDebugMessage(Endpoint endpoint, String message) {
+		if (isDebugMessagesEnabled() && getParentSignalPath().isDebugMessagesEnabled()) {
+			getParentSignalPath().pushToUiChannel(new ModuleDebugMessage(message, endpoint));
+		}
+	}
+
 	/**
 	 * This method is used to serve requests from the UI to individual modules.
 	 * The default implementation inserts the requests into the global event queue
@@ -652,8 +669,7 @@ public abstract class AbstractSignalPathModule implements IEventRecipient, IDayL
 		// By default all modules support runtime parameter changes, ping requests and json requests
 		if (request.getType().equals("ping")) {
 			response.setSuccess(true);
-		}
-		else if (request.getType().equals("paramChange")) {
+		} else if (request.getType().equals("paramChange")) {
 
 			Parameter param = (Parameter) getInput(request.get("param").toString());
 			try {
@@ -681,9 +697,11 @@ public abstract class AbstractSignalPathModule implements IEventRecipient, IDayL
 				log.error("Error making runtime parameter change!", e);
 				getGlobals().getUiChannel().push(new ErrorMessage("Parameter change failed!"), parentSignalPath.getUiChannelId());
 			}
-		}
-		else if (request.getType().equals("json")) {
+		} else if (request.getType().equals("json")) {
 			response.put("json", this.getConfiguration());
+			response.setSuccess(true);
+		} else if (request.getType().equals("debugMessages")) {
+			debugMessagesEnabled = Boolean.parseBoolean(request.get("value").toString());
 			response.setSuccess(true);
 		}
 	}

--- a/src/java/com/unifina/signalpath/Endpoint.java
+++ b/src/java/com/unifina/signalpath/Endpoint.java
@@ -78,6 +78,10 @@ public abstract class Endpoint<T> implements Serializable {
 		id = IdGenerator.get();
 	}
 
+	public String getId() {
+		return id;
+	}
+
 	public Map<String,Object> getConfiguration() {
 		Map<String,Object> map = (json != null ? json : new HashMap<String,Object>());
 

--- a/src/java/com/unifina/signalpath/ModuleDebugMessage.java
+++ b/src/java/com/unifina/signalpath/ModuleDebugMessage.java
@@ -1,0 +1,19 @@
+package com.unifina.signalpath;
+
+import java.util.Date;
+
+public class ModuleDebugMessage extends SignalPathMessage {
+	public ModuleDebugMessage(String msg, AbstractSignalPathModule module) {
+		this.put("type", "MD");
+		this.put("moduleName", module.getEffectiveName());
+		this.put("moduleHash", module.getHash());
+		this.put("canvasTime", module.getGlobals().time);
+		this.put("serverTime", new Date());
+		this.put("msg", msg);
+	}
+
+	public ModuleDebugMessage(String msg, Endpoint endpoint) {
+		this(msg, endpoint.getOwner());
+		this.put("endpoint", endpoint.getId());
+	}
+}

--- a/src/java/com/unifina/signalpath/simplemath/Expression.java
+++ b/src/java/com/unifina/signalpath/simplemath/Expression.java
@@ -10,7 +10,6 @@ import static org.apache.commons.lang3.math.NumberUtils.isNumber;
 public class Expression extends AbstractSignalPathModule {
 	private final StringParameter expressionParam = new StringParameter(this, "expression", "x+y");
 	private final TimeSeriesOutput out = new TimeSeriesOutput(this, "out");
-	private final StringOutput error = new StringOutput(this, "error");
 
 	transient private com.udojava.evalex.Expression expression;
 	private String expressionAsString;
@@ -23,7 +22,6 @@ public class Expression extends AbstractSignalPathModule {
 
 		addInput(expressionParam);
 		addOutput(out);
-		addOutput(error);
 	}
 
 	@Override
@@ -48,7 +46,7 @@ public class Expression extends AbstractSignalPathModule {
 			double value = expression.eval().doubleValue();
 			out.send(value);
 		} catch (RuntimeException e) {
-			error.send(e.getMessage());
+			pushDebugMessage(e.getMessage());
 		}
 	}
 

--- a/web-app/css/compiled-less/main.css
+++ b/web-app/css/compiled-less/main.css
@@ -14837,6 +14837,9 @@ a:hover {
 .module {
   min-width: 150px;
 }
+.module:target .moduleheader {
+  background-color: yellow;
+}
 .moduleheader {
   width: 100%;
   height: 18px;
@@ -15383,6 +15386,19 @@ body.canvas-editor-page #canvas-name-editor:not(.editing) button {
 }
 body.canvas-editor-page #canvas-name-editor .canvas-name {
   cursor: pointer;
+}
+body.canvas-editor-page #canvas-debug-viewer {
+  position: fixed;
+  top: 500px;
+}
+body.canvas-editor-page #canvas-debug-viewer td {
+  padding: 0em 0.5em;
+}
+body.canvas-editor-page #canvas-debug-viewer td:first-child {
+  padding-left: 0;
+}
+body.canvas-editor-page #canvas-debug-viewer td:last-child {
+  padding-right: 0;
 }
 body.canvas-editor-page .breadcrumb {
   margin-bottom: 0px;

--- a/web-app/js/unifina/signalPath/controls/canvas-debug-viewer.js
+++ b/web-app/js/unifina/signalPath/controls/canvas-debug-viewer.js
@@ -1,0 +1,91 @@
+var ModuleDebugMessage = Backbone.Model.extend({});
+
+var ModuleDebugMessageList = Backbone.Collection.extend({
+    model: ModuleDebugMessage,
+
+    initialize: function(options) {
+        options = options || {};
+        this.maxSize = options.maxSize || 30;
+
+        var _this = this
+        this.on("add", function() {
+            if (_this.length > _this.maxSize) {
+                _this.pop();
+                _this.trigger("pop");
+            }
+        });
+    }
+});
+
+var ModuleDebugView = Backbone.View.extend({
+
+    tagName: "tr",
+
+    template: _.template(
+        '<td><a href="#module_{{ moduleHash}}">{{ moduleName }}</a></td>' +
+        '{[ if (this.adhoc) { ]}' +
+            '<td>{{ canvasTime }}</td>' +
+        '{[ } ]}' +
+        '<td>{{ serverTime }}</td>' +
+        '<td>{{ msg }}</td>'
+    ),
+
+    render: function() {
+        this.$el.html(this.template(this.model.toJSON()));
+        return this;
+    }
+});
+
+var CanvasDebugViewer = Backbone.View.extend({
+
+    tagName: "table",
+
+    initialize: function(options) {
+        this.collection = options.collection;
+        this.isAdhoc = options.isAdhoc;
+        this.render();
+        this.collection.bind("add", this._addRender.bind(this));
+        this.collection.bind("pop", this._popRender.bind(this));
+        this.collection.bind("reset", this.render.bind(this));
+    },
+
+    render: function() {
+        this.$thead = $("<thead>");
+        this.$tbody = $("<tbody>");
+        this.$el.empty().append(this.$thead, this.$tbody);
+        this.collection.each(this._addRender.bind(this));
+    },
+
+    _addRender: function(model) {
+        if (this.collection.length === 1) {
+            this._addHeader();
+        }
+
+        var view = new ModuleDebugView({
+            model: model,
+            adhoc: this.isAdhoc()
+        });
+        this.$tbody.prepend(view.render().el);
+    },
+
+    _popRender: function() {
+        this.$tbody.find("tr:last").remove();
+    },
+
+
+    _addHeader: function() {
+        var headerTitles;
+        if (this.isAdhoc()) {
+            headerTitles = ["Module", "Time on Canvas", "Time on Server", "Message"];
+        } else {
+            headerTitles = ["Module", "Time on Server", "Message"];
+        }
+
+        var $headerTr = $("<tr>");
+        _.each(headerTitles, function (key) {
+            $("<th>", {text: key}).appendTo($headerTr);
+        });
+
+        this.$thead.empty().append($headerTr);
+    }
+});

--- a/web-app/js/unifina/signalPath/core/signalPath.js
+++ b/web-app/js/unifina/signalPath/core/signalPath.js
@@ -637,6 +637,9 @@ var SignalPath = (function () {
 			var hash = message.hash;
 			getModuleById(hash).addWarning(message.msg);
 		}
+		else if (message.type=="MD") {
+			$(pub).trigger("moduleDebugMessage", [message])
+		}
 		else if (message.type=="D") {
 			$(pub).trigger("done")
 

--- a/web-app/js/unifina/signalPath/generic/emptyModule.js
+++ b/web-app/js/unifina/signalPath/generic/emptyModule.js
@@ -593,6 +593,17 @@ SignalPath.EmptyModule = function(data, canvas, prot) {
 		return pub.getURL() ? pub.getURL() + '/request' : undefined
 	}
 
+	pub.setDebugMessages = function(enabled) {
+		if (SignalPath.isRunning()) {
+			var msg = { type: "debugMessages", value: enabled }
+			SignalPath.runtimeRequest(pub.getRuntimeRequestURL(), msg, function (response, err) {
+				if (err) {
+					console.error("Failed to set debug message state: %o", err)
+				}
+			})
+		}
+	}
+
 	// Everything added to the public interface can be accessed from the
 	// protected interface too
 	$.extend(prot,pub);

--- a/web-app/less/unifina/pages/canvas-editor.less
+++ b/web-app/less/unifina/pages/canvas-editor.less
@@ -78,6 +78,23 @@ body.canvas-editor-page {
 		}
 	}
 
+	#canvas-debug-viewer {
+		position: fixed;
+		top: 500px;
+
+		td {
+			padding: 0em 0.5em;
+		}
+
+		td:first-child {
+			padding-left: 0;
+		}
+
+		td:last-child {
+			padding-right: 0;
+		}
+	}
+
 	.breadcrumb {
 		margin-bottom: 0px;
 	}

--- a/web-app/less/unifina/signalPath/signalPath.less
+++ b/web-app/less/unifina/signalPath/signalPath.less
@@ -39,6 +39,11 @@
 .module {
 	min-width: 150px;
 }
+
+.module:target .moduleheader {
+	background-color: yellow;
+}
+
 .moduleheader {
 	width: 100%;
 	height: 18px;


### PR DESCRIPTION
Can now send UI debug error messages from AbstractSignalPathModule to
front-end. Can be used to inform user of non-fatal errorneous events.

TODO:
- unit tests
- functional tests?
- placement of UI on canvas editor