### PR TITLE
CORE-848: fix text of Comment module emptying

### DIFF
--- a/src/java/com/unifina/signalpath/utils/Comment.java
+++ b/src/java/com/unifina/signalpath/utils/Comment.java
@@ -2,15 +2,32 @@ package com.unifina.signalpath.utils;
 
 import com.unifina.signalpath.AbstractSignalPathModule;
 
+import java.util.Map;
+
 public class Comment extends AbstractSignalPathModule {
-	
-	@Override
-	public void init() {}
-	
+
+	private String text;
+
 	@Override
 	public void sendOutput() {}
 
 	@Override
 	public void clearState() {}
-	
+
+	@Override
+	public Map<String, Object> getConfiguration() {
+		Map<String, Object> config = super.getConfiguration();
+		if (text != null) {
+			config.put("text", text);
+		}
+		return config;
+	}
+
+	@Override
+	protected void onConfiguration(Map<String, Object> config) {
+		super.onConfiguration(config);
+		if (config.containsKey("text")) {
+			text = config.get("text").toString();
+		}
+	}
 }


### PR DESCRIPTION
Comment text is not saved properly when canvas is saved because of the recent
memory use optimization (Pull request #221)