### PR TITLE
CORE-833: fix Expression module precision problem

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -71,7 +71,7 @@ grails.project.dependency.resolution = {
 		
         compile('org.atmosphere:atmosphere-runtime:1.0.0.beta5')
 		runtime('joda-time:joda-time:2.9.3')
-		compile('com.udojava:EvalEx:1.3')
+		compile('com.udojava:EvalEx:1.6')
 
 		compile('org.apache.kafka:kafka-clients:0.9.0.1')
         compile('com.mashape.unirest:unirest-java:1.3.3')

--- a/src/java/com/unifina/signalpath/simplemath/Expression.java
+++ b/src/java/com/unifina/signalpath/simplemath/Expression.java
@@ -3,6 +3,7 @@ package com.unifina.signalpath.simplemath;
 import com.unifina.service.SerializationService;
 import com.unifina.signalpath.*;
 
+import java.math.MathContext;
 import java.util.*;
 
 import static org.apache.commons.lang3.math.NumberUtils.isNumber;
@@ -62,25 +63,7 @@ public class Expression extends AbstractSignalPathModule {
 	}
 
 	private void initExpressionAndVariables() throws com.udojava.evalex.Expression.ExpressionException {
-		expression = new com.udojava.evalex.Expression(expressionAsString);
-		variables = determineVariables(expression);
-	}
-
-	// TODO: Replace with com.udojava.evalex.Expression#getUsedVariables() when new release of EvalEx is released.
-	private static Iterable<String> determineVariables(com.udojava.evalex.Expression expression) {
-		Set<String> vars = new LinkedHashSet<>();
-		Iterator<String> iterator = expression.getExpressionTokenizer();
-		while (iterator.hasNext()) {
-			String token = iterator.next();
-			if (expression.getDeclaredFunctions().contains(token) ||
-				expression.getDeclaredOperators().contains(token) ||
-				expression.getDeclaredVariables().contains(token)
-				|| token.equals("(") || token.equals(")")
-				|| token.equals(",") || isNumber(token)) {
-				continue;
-			}
-			vars.add(token);
-		}
-		return vars;
+		expression = new com.udojava.evalex.Expression(expressionAsString, MathContext.DECIMAL64);
+		variables = new HashSet<>(expression.getUsedVariables());
 	}
 }

--- a/test/unit/com/unifina/signalpath/simplemath/ExpressionSpec.groovy
+++ b/test/unit/com/unifina/signalpath/simplemath/ExpressionSpec.groovy
@@ -51,4 +51,17 @@ class ExpressionSpec extends Specification {
 		then:
 		module.inputs.size() == 3	// expression, x, y
 	}
+
+	void "CORE-883 can handle large numbers"() {
+		when:
+		module.getInput("expression").receive("x + y")
+		module.configure(module.configuration)
+
+		module.getInput("x").receive(1490357362484)
+		module.getInput("y").receive(360000)
+		module.trySendOutput()
+
+		then:
+		module.getOutput("out").getValue() == 1490357362484d + 360000d
+	}
 }


### PR DESCRIPTION
- Updated Eval-Ex (expression library) to version 1.6.
- Made Expression module work in MathContext.DECIMAL64 mode for precision
  (https://docs.oracle.com/javase/7/docs/api/java/math/MathContext.html#DECIMAL64)