### PR TITLE
CORE-756: service DI into modules (conceptual)

### DIFF
--- a/grails-app/services/com/unifina/service/DependencyInjectionService.groovy
+++ b/grails-app/services/com/unifina/service/DependencyInjectionService.groovy
@@ -1,0 +1,21 @@
+package com.unifina.service
+
+import com.unifina.signalpath.AbstractSignalPathModule
+import com.unifina.signalpath.SignalPath
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
+
+class DependencyInjectionService {
+
+	@Autowired
+	AutowireCapableBeanFactory beanFactory
+
+	@CompileStatic
+	void autowire(AbstractSignalPathModule module) {
+		beanFactory.autowireBean(module)
+		if (module instanceof SignalPath) {
+			((SignalPath) module).modules.each { AbstractSignalPathModule m -> autowire(m) }
+		}
+	}
+}

--- a/grails-app/services/com/unifina/service/ModuleService.groovy
+++ b/grails-app/services/com/unifina/service/ModuleService.groovy
@@ -9,12 +9,15 @@ import com.unifina.utils.Globals
 
 class ModuleService {
 
+	DependencyInjectionService dependencyInjectionService
+
 	@CompileStatic
 	AbstractSignalPathModule getModuleInstance(Module mod, Map config, SignalPath parent, Globals globals) {
 		// TODO: check that the owning user has the privileges to access this module
 
 		ClassLoader cl = this.getClass().getClassLoader()
 		AbstractSignalPathModule m = (AbstractSignalPathModule) cl.loadClass(mod.implementingClass).newInstance()
+		dependencyInjectionService.autowire(m)
 		m.globals = globals
 		m.init()
 		m.setDomainObject(mod)

--- a/grails-app/services/com/unifina/service/SerializationService.groovy
+++ b/grails-app/services/com/unifina/service/SerializationService.groovy
@@ -15,6 +15,7 @@ class SerializationService {
 	final static String INTERVAL_CONFIG_KEY = "streamr.serialization.intervalInMillis"
 
 	GrailsApplication grailsApplication
+	DependencyInjectionService dependencyInjectionService
 	Serializer serializer = new SerializerImpl()
 
 	byte[] serialize(AbstractSignalPathModule module) throws SerializationException {
@@ -26,12 +27,14 @@ class SerializationService {
 
 	AbstractSignalPathModule deserialize(byte[] data) throws SerializationException {
 		AbstractSignalPathModule module = (AbstractSignalPathModule) serializer.deserializeFromByteArray(data)
+		dependencyInjectionService.autowire(module)
 		module.afterDeserialization(this)
 		return module
 	}
 
 	AbstractSignalPathModule deserialize(byte[] data, ClassLoader classLoader) throws SerializationException {
 		AbstractSignalPathModule module = (AbstractSignalPathModule) new SerializerImpl(classLoader).deserializeFromByteArray(data)
+		dependencyInjectionService.autowire(module)
 		module.afterDeserialization(this)
 		return module
 	}

--- a/src/java/com/unifina/signalpath/AbstractSignalPathModule.java
+++ b/src/java/com/unifina/signalpath/AbstractSignalPathModule.java
@@ -22,12 +22,20 @@ import java.util.concurrent.FutureTask;
 
 /**
  * The usual init procedure:
+ *
  * - Construct the module
+ * - Dependency injection
  * - Call module.init()
  * - Call module.setGlobals(globals)
  * - Call module.setName()
  * - Call module.setConfiguration()
  * - Call module.connectionsReady() -> module.initialize()
+ *
+ * The de-serialization procedure:
+ *  - Module de-serialized
+ *  - Dependency injection
+ *  - module.afterDeserialization()
+ *  - module.setGlobals(globals)
  */
 public abstract class AbstractSignalPathModule implements IEventRecipient, IDayListener, Serializable {
 

--- a/src/java/com/unifina/signalpath/streams/SearchStream.java
+++ b/src/java/com/unifina/signalpath/streams/SearchStream.java
@@ -4,6 +4,8 @@ import com.unifina.domain.data.Stream;
 import com.unifina.service.FeedService;
 import com.unifina.service.StreamService;
 import com.unifina.signalpath.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,14 +19,11 @@ public class SearchStream extends AbstractSignalPathModule {
 	private final MapOutput fields = new MapOutput(this, "fields");
 	private final BooleanOutput found = new BooleanOutput(this, "found");
 
+	@Autowired
 	private transient StreamService streamService;
 
 	@Override
 	public void sendOutput() {
-		if (streamService == null) {
-			streamService = getGlobals().getBean(StreamService.class);
-		}
-
 		Stream stream = streamService.findByName(searchName.getValue());
 		if (stream == null) {
 			found.send(false);

--- a/test/unit/com/unifina/signalpath/streams/SearchStreamSpec.groovy
+++ b/test/unit/com/unifina/signalpath/streams/SearchStreamSpec.groovy
@@ -2,7 +2,6 @@ package com.unifina.signalpath.streams
 
 import com.unifina.domain.data.Stream
 import com.unifina.service.StreamService
-import com.unifina.utils.Globals
 import com.unifina.utils.testutils.ModuleTestHelper
 import grails.test.mixin.Mock
 import spock.lang.Specification
@@ -11,14 +10,10 @@ import spock.lang.Specification
 class SearchStreamSpec extends Specification {
 
 	SearchStream module
-	Globals globals
 
 	def setup() {
 		module = new SearchStream()
 		module.init()
-
-		globals = Mock(Globals)
-		globals.getBean(StreamService.class) >> new StreamService()
 
 		Stream stream = new Stream(name: "exists")
 		stream.id = "666-666-666-999"
@@ -43,7 +38,7 @@ class SearchStreamSpec extends Specification {
 
 		then:
 		new ModuleTestHelper.Builder(module, inputValues, outputValues)
-			.overrideGlobals { globals }
+			.injectDependency("streamService", new StreamService())
 			.test()
 	}
 }


### PR DESCRIPTION
I'd like some feedback on this way of accessing services in modules. A common pattern when developing apps with Spring framework is to use `@Autowired` to indicate that a field / setter / constructor will be dependency injected with its collaborators.

Usually `@Autowired` instances are automatically dependency injected on boot up but in our case we instantiate modules ourselves so we need to invoke the dependency injection "manually" on SignalPaths.