### PR TITLE
CORE-759: prevent deletion of running canvases

### DIFF
--- a/grails-app/services/com/unifina/service/CanvasService.groovy
+++ b/grails-app/services/com/unifina/service/CanvasService.groovy
@@ -72,7 +72,9 @@ class CanvasService {
      */
 	@Transactional
 	public void deleteCanvas(Canvas canvas, SecUser user, boolean delayed = false) {
-		if (delayed) {
+		if (canvas.state == Canvas.State.RUNNING) {
+			throw new ApiException(409, "CANNOT_DELETE_RUNNING", "Cannot delete running canvas.")
+		} else if (delayed) {
 			taskService.createTask(CanvasDeleteTask, CanvasDeleteTask.getConfig(canvas), "delete-canvas", user, 30 * 60 * 1000)
 		} else {
 			Collection<Stream> uiChannels = Stream.findAllByUiChannelCanvas(canvas)


### PR DESCRIPTION
Attempting to delete a running canvas will result in API error. Unit tests
for this behaviour.