### PR TITLE
CORE-1071: IntegerParameter#parseValue handle decimal format

### DIFF
--- a/src/java/com/unifina/signalpath/IntegerParameter.java
+++ b/src/java/com/unifina/signalpath/IntegerParameter.java
@@ -17,7 +17,7 @@ public class IntegerParameter extends Parameter<Integer> {
 	
 	@Override
 	public Integer parseValue(String s) {
-		return Integer.parseInt(s);
+		return (int) Double.parseDouble(s);
 	}
 	
 	@Override


### PR DESCRIPTION
CORE-938 changed the way in which JSON is parsed to Java Map.
Specifically, numbers are now always parsed into doubles no matter if
they have a decimal part or not. This left a small bug in
IntegerParameter#parseValue because it cannot handle decimal parts. Now
it does.