### PR TITLE
Readability improvement while reviewing, also removed permission check

### DIFF
--- a/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
+++ b/src/java/com/unifina/signalpath/blockchain/EthereumAccountParameter.java
@@ -25,22 +25,19 @@ class EthereumAccountParameter extends Parameter<IntegrationKey> {
 	}
 
 	String getAddress() {
-		if (hasValue()) {
-			if (getOwner().getGlobals().isRunContext()) {
-				checkPermission();
-			}
-			return (String) ((Map) getValue().toMap().get("json")).get("address");
+		if (!hasValue()) {
+			return null;
 		}
-		return null;
+		return (String) ((Map) getValue().toMap().get("json")).get("address");
 	}
 
 	String getPrivateKey() {
-		EthereumIntegrationKeyService keyService = Holders.getApplicationContext().getBean(EthereumIntegrationKeyService.class);
-		if (hasValue()) {
-			checkPermission();
-			return keyService.decryptPrivateKey(getValue());
+		if (!hasValue()) {
+			return null;
 		}
-		return null;
+		checkPermission();
+		EthereumIntegrationKeyService keyService = Holders.getApplicationContext().getBean(EthereumIntegrationKeyService.class);
+		return keyService.decryptPrivateKey(getValue());
 	}
 
 	private void checkPermission() {
@@ -63,7 +60,6 @@ class EthereumAccountParameter extends Parameter<IntegrationKey> {
 		if (hasValue()) {
 			integrationKeys.add(getValue());
 		}
-
 
 		List<PossibleValue> possibleValues = new ArrayList<>();
 		possibleValues.add(new PossibleValue("(none)", null));


### PR DESCRIPTION
Does it make sense that permission is checked when getting the address? Addresses are public, also the error says "access denied to private key"

getAddress is used only in contexts where it's a getter for address and passed on to streamr-web3 (or checked that if contract has an address)