### PR TITLE
Skip additional intermediate image streamr/grails-docker and use open…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,36 @@
-# Use official OpenJDK 7 Alpine runtime as base image
-FROM streamr/grails-docker
+# Use official OpenJDK 7 as base image
+FROM openjdk:7-jdk
+
+# Set customizable env vars defaults.
+# Set Grails version.
+ENV GRAILS_VERSION 2.5.6
+ENV NODE_VERSION 8.9.4
+
+# Install Grails
+WORKDIR /usr/lib/jvm
+RUN wget https://github.com/grails/grails-core/releases/download/v$GRAILS_VERSION/grails-$GRAILS_VERSION.zip && \
+    unzip grails-$GRAILS_VERSION.zip && \
+    rm -rf grails-$GRAILS_VERSION.zip && \
+    ln -s grails-$GRAILS_VERSION grails
+
+# Setup Grails path
+ENV GRAILS_HOME /usr/lib/jvm/grails
+ENV PATH $GRAILS_HOME/bin:$PATH
+
+# Download and Install Node
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" -o "node-v$NODE_VERSION-linux-x64.tar.xz" \
+    && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+    && rm "node-v$NODE_VERSION-linux-x64.tar.xz"
+
+# Confirm node version
+RUN node --version
+RUN npm --version
+
+# Create App Directory
+RUN mkdir /app
+
+# Set Workdir
+WORKDIR /app
 
 # Copy source code
 COPY . /app
@@ -8,6 +39,8 @@ COPY . /app
 # artifacts.
 RUN grails refresh-dependencies
 RUN grails compile
+
+RUN npm install
 
 # Set Default Behavior
 ENTRYPOINT ["grails"]


### PR DESCRIPTION
Skip additional intermediate image streamr/grails-docker and use openjdk:7-jdk directly.
Basically just included actions from grails-docker into local Dockerfile.