### PR TITLE
CORE-1043: Add anonymous index to Permission table

### DIFF
--- a/grails-app/domain/com/unifina/domain/security/Permission.groovy
+++ b/grails-app/domain/com/unifina/domain/security/Permission.groovy
@@ -60,6 +60,10 @@ class Permission {
 		})
 	}
 
+	static mapping = {
+		anonymous(index: 'anonymous_idx')
+	}
+
 	/**
 	 * Client-side representation of Permission object
 	 * Resource type/id is not indicated because API caller will have it in the URL

--- a/grails-app/migrations/changelog.groovy
+++ b/grails-app/migrations/changelog.groovy
@@ -90,4 +90,5 @@ databaseChangeLog = {
 	include file: 'core/2018-01-16-remove-user-from-domain-objects.groovy'
 	include file: 'core/2018-01-29-remove-mongodb-and-twitter-feeds.groovy'
 	include file: 'core/2018-01-31-mqtt-help-text-update.groovy'
+	include file: 'core/2018-02-12-add-anonymous-index-to-permission.groovy'
 }

--- a/grails-app/migrations/core/2018-02-12-add-anonymous-index-to-permission.groovy
+++ b/grails-app/migrations/core/2018-02-12-add-anonymous-index-to-permission.groovy
@@ -1,0 +1,9 @@
+package core
+
+databaseChangeLog = {
+	changeSet(author: "eric", id: "add-anonymous-index-to-permission") {
+		createIndex(indexName: "anonymous_idx", tableName: "permission") {
+			column(name: "anonymous")
+		}
+	}
+}


### PR DESCRIPTION
Addresses performance issue raised in CORE-1043 by allowing stream
search to use appropriate indexes. This avoids a costly entire full
table scan of stream table.