### PR TITLE
CORE-1148: Alleviate Tour 2 email spam

### DIFF
--- a/test/functional/TourSpec.groovy
+++ b/test/functional/TourSpec.groovy
@@ -368,6 +368,10 @@ class TourSpec extends LoginTester1Spec implements CanvasMixin, ConfirmationMixi
 			connectEndpoints(findOutputByDisplayName("Filter", "A&gt;B"), findInputByDisplayName("Email", "value1"))
 		}
 
+		advance {
+			$(".tourGreaterThan1 .ioSwitch.noRepeat.ioSwitchFalse").click()
+		}
+
 		advance { searchAndClickContains("Table") }
 
 		moveModuleBy("Table", 500, 500)

--- a/web-app/misc/tours/2.js
+++ b/web-app/misc/tours/2.js
@@ -197,6 +197,17 @@
             tour.waitForConnection(['tourFilter1.A&gt;B', 'tourEmail1.value1'])
         )
 
+        .step("One last thing. Hover over the module GreaterThan. Then click the red NR (No Repeat) button just right of <code>A&gt;B</code> so it becomes green.",
+            '.tourGreaterThan1',
+            function(cb) {
+                $(".tourGreaterThan1 .ioSwitch.noRepeat.ioSwitchFalse").click(function() {
+                    tour.next()
+                })
+            }
+        )
+
+        .step("This makes sure the EmailModule does not activate multiple times in a row", ".tourGreaterThan1")
+
         .step("We have now set-up a system that sends us an email every time the number of Bitcoin related tweets within a minute exceeds a threshold.")
 
         .step("Just to make sure that everything is working correctly let's add a Table.<br><br>Add a <strong>Table</strong> to the canvas.",


### PR DESCRIPTION
Reduce amount of emails sent by Tour 2 because of changes in bitcoin
mentions / Twitter API behaviour.

Ps. Functional test "TourSpec" tested and passed.