### PR TITLE
BACK-167: Optimize stream id validation

### DIFF
--- a/src/groovy/com/unifina/domain/CustomStreamIDValidator.groovy
+++ b/src/groovy/com/unifina/domain/CustomStreamIDValidator.groovy
@@ -11,12 +11,21 @@ class CustomStreamIDValidator {
 		boolean isOwnedBy(String domain, User owner)
 	}
 
+	// ENS domain rules:
+	// - must contain two or more segments separated by dot
+    // - segments can contain chars a-z, A-Z, 0-9 and -
+	// https://docs.ens.domains/contract-api-reference/name-processing
+	private static final String ENS_DOMAIN_REGEX = "(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+"
+
 	// path rules:
 	// - must start by slash
 	// - can contain chars a-z, A-Z, 0-9 and -_.
 	// - must not end with non-word character (in this case - or .)
 	// - can have segments separated by slashes (two consecutive slashes is not allowed)
-	public static final Pattern REGEX = Pattern.compile("^((?:[\\w-]+\\.?)*\\w)/(?:[\\w\\.-]+/?)*\\w\$")
+	private static final String PATH_REGEX = "(?:(?:/[\\w\\.-]+)+\\w)|(?:/\\w)"
+
+	private static final String ETHEREUM_ADDRESS_REGEX = "0x[a-fA-F0-9]{40}"
+	private static final Pattern STREAM_ID_REGEX = Pattern.compile("^((?:" + ETHEREUM_ADDRESS_REGEX + ")|(?:" + ENS_DOMAIN_REGEX +"))(?:" + PATH_REGEX + ")\$")
 
 	DomainValidator domainValidator
 
@@ -28,7 +37,7 @@ class CustomStreamIDValidator {
 		if (id == null) {
 			return true
 		} else {
-			Matcher matcher = REGEX.matcher(id)
+			Matcher matcher = STREAM_ID_REGEX.matcher(id)
 			if (matcher.matches()) {
 				String domain = matcher.group(1)
 				return domainValidator.isOwnedBy(domain, creator)

--- a/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
+++ b/test/unit/com/unifina/domain/CustomStreamIDValidatorSpec.groovy
@@ -31,6 +31,7 @@ class CustomStreamIDValidatorSpec extends Specification {
 		"sub.my-domain.eth/foo//bar" | false
 		"foobar.eth/abc/def" | false
 		"sub.my-domain.eth" | false
+		"0xAbcdeabCDE123456789012345678901234567890" | false
 		"0x1111111111111111111111111111111111111111/abc/def" | false
 		"foo" | false
 		"" | false


### PR DESCRIPTION
Updated regex patterns for custom stream id validation. Earlier the nested repetition operators made the parsing extremely slow for some inputs. See http://www.regular-expressions.info/catastrophic.html. E.g. validating of a Ethereum address without a path (`0xAbcdeabCDE123456789012345678901234567890`) required ~200k steps.

The new pattern doesn't allow ENS domain name to contain underscore (as it is not allowed in the ENS spec). Otherwise the updated pattern is compatible with the earlier pattern.