### PR TITLE
fix(api/storage): Fixes BACK-155

### DIFF
--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -39,22 +39,14 @@ class StorageNodeService {
 		return null
 	}
 
-	boolean hasStorageNodeWithAddress(Stream stream, EthereumAddress address) {
-		for (final StreamStorageNode node : stream.getStorageNodes()) {
-			if (node.getStorageNodeAddress() == address.toString()) {
-				return true
-			}
-		}
-		return false
-	}
-
 	StreamStorageNode addStorageNodeToStream(EthereumAddress storageNodeAddress, String streamId) {
 		Stream stream = streamService.getStream(streamId)
 		if (stream == null) {
 			throw new NotFoundException("Stream", streamId)
 		}
-		if (!hasStorageNodeWithAddress(stream, storageNodeAddress)) {
-			StreamStorageNode node = new StreamStorageNode(
+		StreamStorageNode node = findStorageNodeByAddress(stream, storageNodeAddress)
+		if (!node) {
+			node = new StreamStorageNode(
 				storageNodeAddress: storageNodeAddress.toString(),
 				streamId: streamId)
 			stream.addToStorageNodes(node)
@@ -69,13 +61,8 @@ class StorageNodeService {
 			thread.setUncaughtExceptionHandler(new NotifyStorageNodeTask.ErrorHandler())
 			thread.setName(String.format("AddStorageNodeTask[%s,%s]", streamId, storageNodeAddress))
 			thread.start()
-			return node
-		} else {
-			// TODO: https://linear.app/streamr/issue/BACK-155/assign-a-stream-to-a-storage-node-when-it-has-already-been-assigned
-			// TODO: return an instance of StorageNode?
-			//return findStorageNodeByAddress(stream, storageNodeAddress)
-			throw new DuplicateNotAllowedException("StorageNode", storageNodeAddress.toString())
 		}
+		return node
 	}
 
 	void removeStorageNodeFromStream(EthereumAddress storageNodeAddress, String streamId) {

--- a/rest-e2e-tests/src/storagenode-api.test.ts
+++ b/rest-e2e-tests/src/storagenode-api.test.ts
@@ -129,7 +129,7 @@ describe('Storage Node API', () => {
 
 		it('duplicate', async () => {
 			const response = await addStorageNodeToStream(storageNodeAddress, streamId, streamOwner);
-			assert.equal(response.status, 400)
+			assert.equal(response.status, 200)
 		});
 
 		it('validation error', async() => {


### PR DESCRIPTION
When a client tries to assign storage node again (POST /streams/{id}/storageNodes) to the same storage node replies with 200 instead of 400.