### PR TITLE
Improve validation error messages

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -829,7 +829,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: category (typeMismatch)"
+                "message": "Invalid category: foo (typeMismatch)"
               }
             }
           }
@@ -1081,7 +1081,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: category (typeMismatch)"
+                "message": "Invalid category: foo (typeMismatch)"
               }
             }
           }
@@ -1409,7 +1409,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: blockNumber (nullable)"
+                "message": "Invalid blockNumber: foo (nullable)"
               }
             }
           }
@@ -1578,7 +1578,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: blockNumber (nullable)"
+                "message": "Invalid blockNumber: foo (nullable)"
               }
             }
           }
@@ -1661,7 +1661,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: blockNumber (nullable)"
+                "message": "Invalid blockNumber: foo (nullable)"
               }
             }
           }
@@ -2851,7 +2851,7 @@
             "examples": {
               "application/json": {
                 "code": "VALIDATION_ERROR",
-                "message": "Validation failed for fields: address"
+                "message": "Invalid address: foo"
               }
             }
           }

--- a/grails-app/services/com/unifina/service/StreamService.groovy
+++ b/grails-app/services/com/unifina/service/StreamService.groovy
@@ -48,7 +48,7 @@ class StreamService {
 		)
 		stream.id = cmd.id
 		if ((customStreamIDValidator != null) && (!customStreamIDValidator.validate(cmd.id, user))) {
-			throw new ValidationException(new FieldError("stream", "id", cmd.id))
+			throw new ValidationException(new FieldError("stream", "id", cmd.id, false, new String[0], new String[0], null))
 		}
 		if (cmd.name == null || cmd.name.trim() == "") {
 			stream.name = stream.id

--- a/rest-e2e-tests/src/products-api.test.ts
+++ b/rest-e2e-tests/src/products-api.test.ts
@@ -131,7 +131,7 @@ describe('Products API', function () {
                 .create(body)
                 .withAuthenticatedUser(productOwner)
                 .call()
-            await assertResponseIsError(response, 422, 'VALIDATION_ERROR', 'category (typeMismatch)')
+            await assertResponseIsError(response, 422, 'VALIDATION_ERROR', 'Invalid category: non-existing-category-id (typeMismatch)')
         })
 
         it('validates existence of streams (in body)', async () => {
@@ -146,7 +146,7 @@ describe('Products API', function () {
                 .create(body)
                 .withAuthenticatedUser(productOwner)
                 .call()
-            await assertResponseIsError(response, 422, 'VALIDATION_ERROR', 'streams (typeMismatch)')
+            await assertResponseIsError(response, 422, 'VALIDATION_ERROR', 'Invalid streams: [non-existing-stream-id-1, non-existing-stream-id-2] (typeMismatch)')
         })
 
         it('requires stream_share permission on streams (in body)', async () => {

--- a/rest-e2e-tests/src/streams-api.test.ts
+++ b/rest-e2e-tests/src/streams-api.test.ts
@@ -62,14 +62,15 @@ describe('Streams API', () => {
             const request = getStreamrClient(streamOwner).createStream({
                 id: undefined,
             })
-            await assertStreamrClientResponseError(request, 422)
+            await assertStreamrClientResponseError(request, 422, 'VALIDATION_ERROR', `Invalid id`)
         })
 
         it('invalid properties', async function () {
             const request = getStreamrClient(streamOwner).createStream({
+                id: `/${Date.now()}`,
                 partitions: 999,
             })
-            await assertStreamrClientResponseError(request, 422)
+            await assertStreamrClientResponseError(request, 422, 'VALIDATION_ERROR', `Invalid partitions: 999 (max.exceeded)`)
         })
 
         it('create with owned domain id', async function () {
@@ -96,7 +97,7 @@ describe('Streams API', () => {
                 id: streamId,
             }
             const request = getStreamrClient(streamOwner).createStream(properties)
-            await assertStreamrClientResponseError(request, 422)
+            await assertStreamrClientResponseError(request, 422, 'VALIDATION_ERROR', `Invalid id: ${streamId}`)
         })
 
         it('create stream with duplicate id', async function () {
@@ -109,7 +110,7 @@ describe('Streams API', () => {
             const response = await getStreamrClient(ensDomainOwner).createStream(properties)
             assert.equal(response.id, streamId)
             const errorResponse = getStreamrClient(ensDomainOwner).createStream(properties)
-            await assertStreamrClientResponseError(errorResponse, 400)
+            await assertStreamrClientResponseError(errorResponse, 400, 'DUPLICATE_NOT_ALLOWED', `Stream with id ${streamId} already exists`)
         })
 
         it('create stream with too long id', async function () {
@@ -121,27 +122,29 @@ describe('Streams API', () => {
                 id: streamId,
             }
             const response = getStreamrClient(ensDomainOwner).createStream(properties)
-            await assertStreamrClientResponseError(response, 422)
+            await assertStreamrClientResponseError(response, 422, 'VALIDATION_ERROR', `Invalid id: ${streamId}`)
         })
 
         it('create stream with too long description', async function () {
             let streamId = 'testdomain1.eth/foobar/' + Date.now()
+            const description = 'x'.repeat(256)
             const properties = {
                 id: streamId,
-                description: 'x'.repeat(256),
+                description
             }
             const response = getStreamrClient(ensDomainOwner).createStream(properties)
-            await assertStreamrClientResponseError(response, 422)
+            await assertStreamrClientResponseError(response, 422, 'VALIDATION_ERROR', `Invalid description: ${description}`)
         })
 
         it('create stream with too long name', async function () {
             let streamId = 'testdomain1.eth/foobar/' + Date.now()
+            const name = 'x'.repeat(256)
             const properties = {
                 id: streamId,
-                name: 'x'.repeat(256),
+                name
             }
             const response = getStreamrClient(ensDomainOwner).createStream(properties)
-            await assertStreamrClientResponseError(response, 422)
+            await assertStreamrClientResponseError(response, 422, 'VALIDATION_ERROR', `Invalid name: ${name}`)
         })
     })
 

--- a/rest-e2e-tests/src/test-utilities.ts
+++ b/rest-e2e-tests/src/test-utilities.ts
@@ -13,13 +13,15 @@ export const assertResponseIsError = async (response: any, statusCode: number, p
 	}
 }
 
-export const assertStreamrClientResponseError = async (request: any, expectedStatusCode: number) => {
+export const assertStreamrClientResponseError = async (request: any, expectedStatusCode: number, programmaticCode: string, includeInMessage: string) => {
 	return request
 		.then(() => {
 			assert.fail('Should response with an error code')
 		})
 		.catch((e: any) => {
 			assert.equal(e.response.status, expectedStatusCode)
+			assert.include(e.message, programmaticCode)
+			assert.include(e.message, includeInMessage)
 		})
 }
 

--- a/src/java/com/unifina/service/ValidationException.java
+++ b/src/java/com/unifina/service/ValidationException.java
@@ -1,6 +1,9 @@
 package com.unifina.service;
 import java.util.List;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
@@ -21,10 +24,20 @@ public class ValidationException extends RuntimeException {
 	}
 
 	private static String turnToMessage(List<FieldError> errors) {
-		String msg = "Validation failed for fields:\n";
-		for (FieldError error : errors) {
-			msg += error.getField() + " (" + error.getCode() + ")\n";
+		return "Invalid " + errors
+			.stream()
+			.map(ValidationException::createFieldErrorDescription)
+			.collect(Collectors.joining(", "));
+	}
+
+	private static String createFieldErrorDescription(FieldError error) {
+		String s = error.getField();
+		if (error.getRejectedValue() != null) {
+			s += ": " + error.getRejectedValue();
 		}
-		return msg;
+		if (error.getCode() != null) {
+			s += " (" + error.getCode() + ")";
+		}
+		return s;
 	}
 }


### PR DESCRIPTION
The `ValidationException` message now includes the rejected value. The content is shorter and easier to interpret, e.g.:

```
Invalid id: 0x1234567890/foobar
Invalid partitions: 999 (max.exceeded)
Invalid category: non-existing-category-id (typeMismatch)
```