### PR TITLE
fix: slow permission query killing core-api

### DIFF
--- a/grails-app/services/com/unifina/service/PermissionStore.groovy
+++ b/grails-app/services/com/unifina/service/PermissionStore.groovy
@@ -10,23 +10,39 @@ class PermissionStore {
 	}
 
 	List<Permission> findDirectPermissions(String resourceProp, Object resource, Permission.Operation operation, Userish userish) {
-		List<Permission> directPermissions = Permission.withCriteria {
-			eq(resourceProp, resource)
-			if (operation != null) {
-				eq("operation", operation)
-			}
-			or {
-				eq("anonymous", true)
-				if (isNotNullAndIdNotNull(userish)) {
-					String userProp = PermissionService.getUserPropertyName(userish)
-					eq(userProp, userish)
+		List<Permission> directPermissions = new LinkedList<>();
+		
+		// first find only user-specific Permissions (100..1000x faster than "anonymous OR user-specific" query)
+		if (isNotNullAndIdNotNull(userish)) {
+			String userProp = PermissionService.getUserPropertyName(userish)
+			directPermissions = Permission.withCriteria {
+				eq(resourceProp, resource)
+				if (operation != null) {
+					eq("operation", operation)
+				}
+				eq(userProp, userish)
+				or {
+					isNull("endsAt")
+					gt("endsAt", new Date())
 				}
 			}
-			or {
-				isNull("endsAt")
-				gt("endsAt", new Date())
+		}
+
+		// if no user-specific permissions found, do the slower anonymous permissions query (still 10x faster than "OR" query)
+		if (directPermissions.size() < 0) {
+			directPermissions = Permission.withCriteria {
+				eq(resourceProp, resource)
+				if (operation != null) {
+					eq("operation", operation)
+				}
+				eq("anonymous", true)
+				or {
+					isNull("endsAt")
+					gt("endsAt", new Date())
+				}
 			}
 		}
+
 		return directPermissions
 	}
 

--- a/grails-app/services/com/unifina/service/PermissionStore.groovy
+++ b/grails-app/services/com/unifina/service/PermissionStore.groovy
@@ -11,7 +11,7 @@ class PermissionStore {
 
 	List<Permission> findDirectPermissions(String resourceProp, Object resource, Permission.Operation operation, Userish userish) {
 		List<Permission> directPermissions = new LinkedList<>();
-		
+
 		// first find only user-specific Permissions (100..1000x faster than "anonymous OR user-specific" query)
 		if (isNotNullAndIdNotNull(userish)) {
 			String userProp = PermissionService.getUserPropertyName(userish)
@@ -29,7 +29,7 @@ class PermissionStore {
 		}
 
 		// if no user-specific permissions found, do the slower anonymous permissions query (still 10x faster than "OR" query)
-		if (directPermissions.size() < 0) {
+		if (directPermissions.isEmpty()) {
 			directPermissions = Permission.withCriteria {
 				eq(resourceProp, resource)
 				if (operation != null) {

--- a/test/unit/com/unifina/service/PermissionServiceSpec.groovy
+++ b/test/unit/com/unifina/service/PermissionServiceSpec.groovy
@@ -95,7 +95,7 @@ class PermissionServiceSpec extends BeanMockingSpecification {
 		service.getPermissionsTo(streamRestricted, stranger) == []
 		service.getPermissionsTo(streamRestricted, null) == []
 		service.getPermissionsTo(streamPublic, me)[0].operation == Operation.STREAM_GET
-		service.getPermissionsTo(streamPublic, anotherUser).size() == 1 + Operation.streamOperations().size()
+		service.getPermissionsTo(streamPublic, anotherUser).size() == Operation.streamOperations().size()
 		service.getPermissionsTo(streamPublic, stranger)[0].operation == Operation.STREAM_GET
 		service.getPermissionsTo(streamPublic, null)[0].operation == Operation.STREAM_GET
 	}


### PR DESCRIPTION
Problem:
* MySQL cpu usage at 770%
* `show full processlist;` showing 102 processes from streamr-prod-2 in queue at all times
* those queries VERY slow (50 seconds)

Quick testing:
* get only user-specific permission: 0.2s
* get only anonymous permission (when there are none): 5s
* get user-specific OR anonymous permission: 50s

Solution: only ask MySQL for anonymous permissions if no user-specific permissions found.

Reason could be a bad index: in `TABLE permission`, there is `KEY `anonymous_idx` (`anonymous`)` but that column only has 2 possible values. So maybe not so good to index it.