### PR TITLE
add storage node address to notification message

### DIFF
--- a/src/java/com/unifina/service/NotifyStorageNodeTask.java
+++ b/src/java/com/unifina/service/NotifyStorageNodeTask.java
@@ -61,6 +61,7 @@ final class NotifyStorageNodeTask implements Runnable {
 		stream.put("id", streamId);
 		stream.put("partitions", streamService.getStream(streamId).getPartitions());
 		message.put("stream", stream);
+		message.put("storageNode", storageNodeAddress);
 		return message;
 	}
 }


### PR DESCRIPTION
The message to notify storage nodes about new storage assignments did not contain what storage node the stream was assigned to!