### PR TITLE
Proof of concept fix for corrupt message chains in storage node assignment streams.

### DIFF
--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -39,7 +39,7 @@ class StorageNodeService {
 		return null
 	}
 
-	StreamStorageNode addStorageNodeToStream(EthereumAddress storageNodeAddress, String streamId) {
+	synchronized StreamStorageNode addStorageNodeToStream(EthereumAddress storageNodeAddress, String streamId) {
 		Stream stream = streamService.getStream(streamId)
 		if (stream == null) {
 			throw new NotFoundException("Stream", streamId)
@@ -61,11 +61,12 @@ class StorageNodeService {
 			thread.setUncaughtExceptionHandler(new NotifyStorageNodeTask.ErrorHandler())
 			thread.setName(String.format("AddStorageNodeTask[%s,%s]", streamId, storageNodeAddress))
 			thread.start()
+			thread.join()
 		}
 		return node
 	}
 
-	void removeStorageNodeFromStream(EthereumAddress storageNodeAddress, String streamId) {
+	synchronized void removeStorageNodeFromStream(EthereumAddress storageNodeAddress, String streamId) {
 		Stream stream = streamService.getStream(streamId)
 		if (stream == null) {
 			throw new NotFoundException("Stream", streamId)
@@ -84,6 +85,7 @@ class StorageNodeService {
 			thread.setUncaughtExceptionHandler(new NotifyStorageNodeTask.ErrorHandler())
 			thread.setName(String.format("RemoveStorageNodeTask[%s,%s]", streamId, storageNodeAddress))
 			thread.start()
+			thread.join()
 		} else {
 			throw new NotFoundException("StorageNode", storageNodeAddress.toString())
 		}


### PR DESCRIPTION
This isn't a good fix, but it resolves the issues I was seeing and confirms that the problem is async. 

When running client tests that generate 20 storage node assignments in parallel, some storage node assignments were not appearing in the assignment stream. They just never appear. 

A few moments after `core-api` logs `addStorageNodeToStream` for the missing stream, there would be another message like `Protocol error message: 'prevMessageRef cannot be identical to current.` or `Protocol error message: 'prevMessageRef must come before current.`. These messages come from the js protocol, forwarded by the broker's message validation. What I believe is happening is that `core-api` starts a new thread to do the publishing:
https://github.com/streamr-dev/core-api/blob/466c9e15e7afce06a8c7175cd25c96adc8d597de/grails-app/services/com/unifina/service/StorageNodeService.groovy#L54-L63

which calls `client.publish` in this `Runnable`:

https://github.com/streamr-dev/core-api/blob/466c9e15e7afce06a8c7175cd25c96adc8d597de/src/java/com/unifina/service/NotifyStorageNodeTask.java#L46-L55

But publish sequencing in the java client doesn't appear to be threadsafe, so it's getting incorrect results for `sequenceNumber` and/or `prevMessageRef`, leading to corrupt message chain:
https://github.com/streamr-dev/streamr-client-java/blob/3d16eb05ec2a681c3ab8f3ea2f51aa1b0c5ed1f9/src/main/java/com/streamr/client/utils/MessageCreationUtil.java#L211-L231

Not suggesting this is merged as-is, since there's no point having the thread code in there if we're synchronising + join, just opening this for discussion.