### PR TITLE
optimize findStreamsByStorageNode

### DIFF
--- a/grails-app/services/com/unifina/service/StorageNodeService.groovy
+++ b/grails-app/services/com/unifina/service/StorageNodeService.groovy
@@ -12,13 +12,7 @@ class StorageNodeService {
 	StreamrClientService streamrClientService
 
 	List<Stream> findStreamsByStorageNode(EthereumAddress storageNodeAddress) {
-		List<StreamStorageNode> nodes = StreamStorageNode.findAllByStorageNodeAddress(storageNodeAddress.toString())
-		List<Stream> results = new ArrayList<>()
-		for (StreamStorageNode node : nodes) {
-			Stream stream = node.getStream()
-			results.add(stream)
-		}
-		return results
+		return Stream.findAll("FROM Stream WHERE id IN (SELECT streamId FROM StreamStorageNode WHERE storageNodeAddress=?)", [storageNodeAddress.toString()])
 	}
 
 	Set<StreamStorageNode> findStorageNodesByStream(String streamId) {


### PR DESCRIPTION
Optimized `/api/v1/storageNodes/:streamId/streams` endpoint. 

Previously we fetched the list of `streamIds` and the fetched each stream one by one  The new implementation uses single query to fetch all required data.

Previously the endpoint query took about 14 seconds if there is 10000 streams in a storage node (in local environment). After the optimization the same operation takes about 1 second.