### PR TITLE
Fix bad serialization of storageNodeAddress.

### DIFF
--- a/src/groovy/com/unifina/domain/EthereumAddress.groovy
+++ b/src/groovy/com/unifina/domain/EthereumAddress.groovy
@@ -22,6 +22,7 @@ class EthereumAddress {
 		this.value = Keys.toChecksumAddress(value)
 	}
 
+	@Override
 	public String toString() {
 		return value
 	}

--- a/src/java/com/unifina/service/NotifyStorageNodeTask.java
+++ b/src/java/com/unifina/service/NotifyStorageNodeTask.java
@@ -61,7 +61,7 @@ final class NotifyStorageNodeTask implements Runnable {
 		stream.put("id", streamId);
 		stream.put("partitions", streamService.getStream(streamId).getPartitions());
 		message.put("stream", stream);
-		message.put("storageNode", storageNodeAddress);
+		message.put("storageNode", storageNodeAddress.toString());
 		return message;
 	}
 }


### PR DESCRIPTION
This seems to be serialized as `{storageNode: {value: string}}` instead of just `{storageNode: string}`, which breaks the broker.