### PR TITLE
BACK-202: update migration fields

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,12 +4,13 @@ streamr-docker-dev
 .slcache
 out
 .git
-terraform*
 Dockerfile
 **/node_modules
 **/.DS_Store
 README.md
 LICENSE
-target/stacktrace.log
-target/test-classes
-target/test-reports
+target/*/*
+*.patch
+*.diff
+*.sql
+*.gz

--- a/grails-app/controllers/com/unifina/controller/StreamApiController.groovy
+++ b/grails-app/controllers/com/unifina/controller/StreamApiController.groovy
@@ -82,6 +82,10 @@ class StreamApiController {
 			if (newStream.inactivityThresholdHours != null) {
 				stream.inactivityThresholdHours = newStream.inactivityThresholdHours
 			}
+			if (newStream.migrateToBrubeck == true) {
+				stream.migrateToBrubeck = true
+				stream.migrateSyncTurnedOnAt = new Date()
+			}
 			if (stream.validate()) {
 				stream.save(failOnError: true)
 				render(stream.toMap() as JSON)

--- a/test/unit/com/unifina/controller/StreamApiControllerSpec.groovy
+++ b/test/unit/com/unifina/controller/StreamApiControllerSpec.groovy
@@ -202,6 +202,7 @@ class StreamApiControllerSpec extends ControllerSpecification {
 			inactivityThresholdHours: 99,
 			partitions: 5,
 			requireEncryptedData: true,
+			migrateToBrubeck: true,
 		]
 
 		when:
@@ -214,6 +215,9 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		response.json.storageDays == 24
 		response.json.inactivityThresholdHours == 99
 		response.json.partitions == 5
+		response.json.migrateToBrubeck == true
+		response.json.migrateSyncTurnedOnAt != null
+		response.json.migrateSyncLastRunAt == null
 
 		then:
 		def stream = streamOne
@@ -226,6 +230,9 @@ class StreamApiControllerSpec extends ControllerSpecification {
 		stream.storageDays == 24
 		stream.inactivityThresholdHours == 99
 		stream.partitions == 5
+		stream.migrateToBrubeck == true
+		stream.migrateSyncTurnedOnAt != null
+		stream.migrateSyncLastRunAt == null
 	}
 
 	void "update a Stream of logged in user but do not update undefined fields"() {


### PR DESCRIPTION
When Stream is updated (HTTP PUT) with `migrateToBrubeck = true` set `migrateToBrubeck` to `true` and set `migrateSyncTurnedOnAt` to current time.